### PR TITLE
Update samples to use 2.17.* SDK

### DIFF
--- a/OneToOne/Droid/DT.Samples.Opentok.OneToOne.Droid.csproj
+++ b/OneToOne/Droid/DT.Samples.Opentok.OneToOne.Droid.csproj
@@ -123,7 +123,7 @@
       <HintPath>..\..\packages\Xamarin.Android.Support.Design.27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Design.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.OpenTok.Android">
-      <HintPath>..\..\packages\Xamarin.OpenTok.Android.2.16.5-beta1\lib\MonoAndroid\Xamarin.OpenTok.Android.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.OpenTok.Android.2.17.2\lib\MonoAndroid\Xamarin.OpenTok.Android.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/OneToOne/Droid/packages.config
+++ b/OneToOne/Droid/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Xam.Plugins.Settings" version="3.1.1" targetFramework="monoandroid51" />
   <package id="Xamarin.Android.Arch.Core.Common" version="1.0.0.1" targetFramework="monoandroid81" />
@@ -17,5 +17,5 @@
   <package id="Xamarin.Android.Support.v7.AppCompat" version="27.0.2.1" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Support.v7.RecyclerView" version="27.0.2.1" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Support.Vector.Drawable" version="27.0.2.1" targetFramework="monoandroid81" />
-  <package id="Xamarin.OpenTok.Android" version="2.16.5-beta1" targetFramework="monoandroid81" />
+  <package id="Xamarin.OpenTok.Android" version="2.17.2" targetFramework="monoandroid81" />
 </packages>

--- a/OneToOne/iOS/DT.Samples.Opentok.OneToOne.iOS.csproj
+++ b/OneToOne/iOS/DT.Samples.Opentok.OneToOne.iOS.csproj
@@ -172,7 +172,7 @@
       <HintPath>..\..\packages\Xam.Plugins.Settings.3.1.1\lib\Xamarin.iOS10\Plugin.Settings.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.OpenTok.iOS">
-      <HintPath>..\..\packages\Xamarin.OpenTok.iOS.2.16.5-beta1\lib\Xamarin.iOS10\Xamarin.OpenTok.iOS.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.OpenTok.iOS.2.17.1\lib\Xamarin.iOS10\Xamarin.OpenTok.iOS.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/OneToOne/iOS/packages.config
+++ b/OneToOne/iOS/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Xam.Plugins.Settings" version="3.1.1" targetFramework="xamarinios10" />
-  <package id="Xamarin.OpenTok.iOS" version="2.16.5-beta1" targetFramework="xamarinios10" />
+  <package id="Xamarin.OpenTok.iOS" version="2.17.1" targetFramework="xamarinios10" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,39 @@ Xamarin.OpenTok.Android - includes all capabilities [![NuGet Badge](https://buil
 
 Xamarin.OpenTok.iOS - includes all capabilities [![NuGet Badge](https://buildstats.info/nuget/Xamarin.OpenTok.iOS)](https://www.nuget.org/packages/Xamarin.OpenTok.iOS/)
 
+
+### Additional logging capabilities for Xamarin iOS SDK
+
+To enable additional logging on iOS, please call this method before any Vonage SDK activity:
+
+```
+            OpenTok.OpenTokExtraLogging.EnableOpenTokLoggingToConsole();
+```
+
+The output will be visible in Visual Studio _Application Output_ window:
+
+```
+
+*******************************************************
+NOTICE: OPENTOK CONSOLE LOGGER HAS NOT BEEN SET.
+PLEASE USE otk_console_set_logger(otk_console_logger)
+TO SET YOUR LOGGER.
+*******************************************************
+2020-08-28 05:07:40,904 UTC [DEBUG] otk_peer_connection.cpp:1174 - Thread 0xc07d480f01000000 - otk_enable_webrtc_trace[otk_enable_webrtc_trace_levels level=0]
+2020-08-28 01:07:40.906735-0400 DT.Samples.Opentok.OneToOne.iOS[99671:3738797] 
+2020-08-28 01:07:40.906816-0400 DT.Samples.Opentok.OneToOne.iOS[99671:3738797] ------------------------------------------------
+2020-08-28 01:07:40.906894-0400 DT.Samples.Opentok.OneToOne.iOS[99671:3738797] OpenTok iOS Library, Rev.2
+2020-08-28 01:07:40.906950-0400 DT.Samples.Opentok.OneToOne.iOS[99671:3738797] This build was born on Jul 16 2020 at 01:19:25
+2020-08-28 01:07:40.912500-0400 DT.Samples.Opentok.OneToOne.iOS[99671:3738797] Version: 2.17.1.9206-ios
+2020-08-28 01:07:40.912598-0400 DT.Samples.Opentok.OneToOne.iOS[99671:3738797] libOpenTokObjC:9beaf26eb6282257d2a4e64e8ea859953136f272
+2020-08-28 01:07:40.912864-0400 DT.Samples.Opentok.OneToOne.iOS[99671:3738797] Licensed under the Apache License, Version 2.0
+2020-08-28 01:07:40.913036-0400 DT.Samples.Opentok.OneToOne.iOS[99671:3738797] ------------------------------------------------
+2020-08-28 01:07:40.915607-0400 DT.Samples.Opentok.OneToOne.iOS[99671:3739045] [DEBUG] otk_ssl_util.c:245 - otk_ssl_static_init_default[]
+2020-08-28 01:07:40.917427-0400 DT.Samples.Opentok.OneToOne.iOS[99671:3739045] [DEBUG] otk_ssl_util.c:35 - otk_ssl_enable_verify_peer_impl[]
+...
+
+```
+
 ## License
 
 The MIT License (MIT).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# [OpenTok](https://tokbox.com/) Xamarin iOS/Android sample project
+# [Vonage Video API (previously OpenTok)](https://www.vonage.com/communications-apis/video/) Xamarin iOS/Android sample project
 
-Sample showing how to integrate Tokbox Opentok SDK into Xamarin iOS/Android apps
+Sample showing how to integrate Vonage Video API (Opentok) SDK into Xamarin iOS/Android apps
 
-The OpenTok SDK allows you to build live interactive video, voice and messaging into your web and mobile apps
+The Vonage Video API SDK allows you to build live interactive video, voice and messaging into your web and mobile apps
 
 ## Xamarin.iOS and Xamarin.Android OpenTok SDK packages
 


### PR DESCRIPTION
- update iOS and Android samples to use latest available Vonage/OpenTok SDK for Xamarin (2.17.*)
- update Readme to include new SDK name (Vonage Video API SDK)
- update Readme to include information on how to enable additional Vonage Video API SDK logs on iOS platform